### PR TITLE
Add Back Button support on Android

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -25,47 +25,78 @@ class MyHomePage extends StatefulWidget {
 }
 
 class _MyHomePageState extends State<MyHomePage> {
+  final List<MenuScreenHistoryEntry> _history = [
+    new MenuScreenHistoryEntry(
+      restaurantScreen,
+      MenuItemId.restaurant,
+    )
+  ];
 
   final menu = new Menu(
     items: [
       new MenuItem(
-        id: 'restaurant',
+        id: MenuItemId.restaurant,
         title: 'THE PADDOCK',
       ),
       new MenuItem(
-        id: 'other1',
+        id: MenuItemId.other1,
         title: 'THE HERO',
       ),
       new MenuItem(
-        id: 'other2',
+        id: MenuItemId.other2,
         title: 'HELP US GROW',
       ),
       new MenuItem(
-        id: 'other3',
+        id: MenuItemId.other3,
         title: 'SETTINGS',
       ),
     ],
   );
-
-  var selectedMenuItemId = 'restaurant';
-  var activeScreen = restaurantScreen;
 
   @override
   Widget build(BuildContext context) {
     return new ZoomScaffold(
       menuScreen: new MenuScreen(
         menu: menu,
-        selectedItemId: selectedMenuItemId,
-        onMenuItemSelected: (String itemId) {
-          selectedMenuItemId = itemId;
-          if (itemId == 'restaurant') {
-            setState(() => activeScreen = restaurantScreen);
-          } else {
-            setState(() => activeScreen = otherScreen);
-          }
-        },
+        selectedItemId: _history.last.id,
+        onMenuItemSelected: _pushPage,
       ),
-      contentScreen: activeScreen,
+      contentScreen: _history.last.screen,
     );
   }
+
+  void _pushPage(MenuItem item) {
+    setState(() {
+      final route = ModalRoute.of(context);
+      final entry = new LocalHistoryEntry(onRemove: _popPage);
+      route.addLocalHistoryEntry(entry);
+
+      switch (item.id) {
+        case MenuItemId.restaurant:
+          _history.add(new MenuScreenHistoryEntry(
+            restaurantScreen,
+            item.id,
+          ));
+          break;
+        default:
+          _history.add(new MenuScreenHistoryEntry(
+            buildOtherScreen(item.title),
+            item.id,
+          ));
+      }
+    });
+  }
+
+  void _popPage() {
+    setState(() {
+      _history.removeLast();
+    });
+  }
+}
+
+class MenuScreenHistoryEntry {
+  final Screen screen;
+  final MenuItemId id;
+
+  MenuScreenHistoryEntry(this.screen, this.id);
 }

--- a/lib/menu_screen.dart
+++ b/lib/menu_screen.dart
@@ -4,10 +4,9 @@ import 'package:zoom_menu/zoom_scaffold.dart';
 final menuScreenKey = new GlobalKey(debugLabel: 'MenuScreen');
 
 class MenuScreen extends StatefulWidget {
-
   final Menu menu;
-  final String selectedItemId;
-  final Function(String) onMenuItemSelected;
+  final MenuItemId selectedItemId;
+  final Function(MenuItem) onMenuItemSelected;
 
   MenuScreen({
     this.menu,
@@ -20,7 +19,6 @@ class MenuScreen extends StatefulWidget {
 }
 
 class _MenuScreenState extends State<MenuScreen> with TickerProviderStateMixin {
-
   AnimationController titleAnimationController;
   double selectorYTop;
   double selectorYBottom;
@@ -64,66 +62,62 @@ class _MenuScreenState extends State<MenuScreen> with TickerProviderStateMixin {
     }
 
     return new AnimatedBuilder(
-      animation: titleAnimationController,
-      child: new OverflowBox(
-        maxWidth: double.infinity,
-        alignment: Alignment.topLeft,
-        child: new Padding(
-          padding: const EdgeInsets.all(30.0),
-          child: new Text(
-            'Menu',
-            style: new TextStyle(
-              color: const Color(0x88444444),
-              fontSize: 240.0,
-              fontFamily: 'mermaid',
+        animation: titleAnimationController,
+        child: new OverflowBox(
+          maxWidth: double.infinity,
+          alignment: Alignment.topLeft,
+          child: new Padding(
+            padding: const EdgeInsets.all(30.0),
+            child: new Text(
+              'Menu',
+              style: new TextStyle(
+                color: const Color(0x88444444),
+                fontSize: 240.0,
+                fontFamily: 'mermaid',
+              ),
+              textAlign: TextAlign.left,
+              softWrap: false,
             ),
-            textAlign: TextAlign.left,
-            softWrap: false,
           ),
         ),
-      ),
-      builder: (BuildContext context, Widget child) {
-        return new Transform(
-          transform: new Matrix4.translationValues(
-            250.0 * (1.0 - titleAnimationController.value) - 100.0,
-            0.0,
-            0.0,
-          ),
-          child: child,
-        );
-      }
-    );
+        builder: (BuildContext context, Widget child) {
+          return new Transform(
+            transform: new Matrix4.translationValues(
+              250.0 * (1.0 - titleAnimationController.value) - 100.0,
+              0.0,
+              0.0,
+            ),
+            child: child,
+          );
+        });
   }
 
   createMenuItems(MenuController menuController) {
     final List<Widget> listItems = [];
     final animationIntervalDuration = 0.5;
-    final perListItemDelay = menuController.state != MenuState.closing ? 0.15 : 0.0;
+    final perListItemDelay =
+        menuController.state != MenuState.closing ? 0.15 : 0.0;
     for (var i = 0; i < widget.menu.items.length; ++i) {
       final animationIntervalStart = i * perListItemDelay;
-      final animationIntervalEnd = animationIntervalStart + animationIntervalDuration;
+      final animationIntervalEnd =
+          animationIntervalStart + animationIntervalDuration;
       final isSelected = widget.menu.items[i].id == widget.selectedItemId;
 
-      listItems.add(
-          new AnimatedMenuListItem(
-            menuState: menuController.state,
-            isSelected: isSelected,
-            duration: const Duration(milliseconds: 600),
-            curve: new Interval(
-                animationIntervalStart,
-                animationIntervalEnd,
-                curve: Curves.easeOut
-            ),
-            menuListItem: new _MenuListItem(
-              title: widget.menu.items[i].title,
-              isSelected: isSelected,
-              onTap: () {
-                widget.onMenuItemSelected(widget.menu.items[i].id);
-                menuController.close();
-              },
-            ),
-          )
-      );
+      listItems.add(new AnimatedMenuListItem(
+        menuState: menuController.state,
+        isSelected: isSelected,
+        duration: const Duration(milliseconds: 600),
+        curve: new Interval(animationIntervalStart, animationIntervalEnd,
+            curve: Curves.easeOut),
+        menuListItem: new _MenuListItem(
+          title: widget.menu.items[i].title,
+          isSelected: isSelected,
+          onTap: () {
+            Navigator.pop(context);
+            widget.onMenuItemSelected(widget.menu.items[i]);
+          },
+        ),
+      ));
     }
 
     return new Transform(
@@ -132,7 +126,7 @@ class _MenuScreenState extends State<MenuScreen> with TickerProviderStateMixin {
         225.0,
         0.0,
       ),
-      child: Column(
+      child: new Column(
         children: listItems,
       ),
     );
@@ -141,60 +135,59 @@ class _MenuScreenState extends State<MenuScreen> with TickerProviderStateMixin {
   @override
   Widget build(BuildContext context) {
     return new ZoomScaffoldMenuController(
-      builder: (BuildContext context, MenuController menuController) {
-        var shouldRenderSelector = true;
-        var actualSelectorYTop = selectorYTop;
-        var actualSelectorYBottom = selectorYBottom;
-        var selectorOpacity = 1.0;
+        builder: (BuildContext context, MenuController menuController) {
+      var shouldRenderSelector = true;
+      var actualSelectorYTop = selectorYTop;
+      var actualSelectorYBottom = selectorYBottom;
+      var selectorOpacity = 1.0;
 
-        if (menuController.state == MenuState.closed
-            || menuController.state == MenuState.closing
-            || selectorYTop == null) {
-          final RenderBox menuScreenRenderBox = context.findRenderObject() as RenderBox;
+      if (menuController.state == MenuState.closed ||
+          menuController.state == MenuState.closing ||
+          selectorYTop == null) {
+        final RenderBox menuScreenRenderBox =
+            context.findRenderObject() as RenderBox;
 
-          if (menuScreenRenderBox != null) {
-            final menuScreenHeight = menuScreenRenderBox.size.height;
-            actualSelectorYTop = menuScreenHeight - 50.0;
-            actualSelectorYBottom = menuScreenHeight;
-            selectorOpacity = 0.0;
-          } else {
-            shouldRenderSelector = false;
-          }
+        if (menuScreenRenderBox != null) {
+          final menuScreenHeight = menuScreenRenderBox.size.height;
+          actualSelectorYTop = menuScreenHeight - 50.0;
+          actualSelectorYBottom = menuScreenHeight;
+          selectorOpacity = 0.0;
+        } else {
+          shouldRenderSelector = false;
         }
+      }
 
-        return new Container(
-          width: double.infinity,
-          height: double.infinity,
-          decoration: new BoxDecoration(
-            image: new DecorationImage(
-              image: new AssetImage('assets/dark_grunge_bk.jpg'),
-              fit: BoxFit.cover,
-            ),
+      return new Container(
+        width: double.infinity,
+        height: double.infinity,
+        decoration: new BoxDecoration(
+          image: new DecorationImage(
+            image: new AssetImage('assets/dark_grunge_bk.jpg'),
+            fit: BoxFit.cover,
           ),
-          child: new Material(
-            color: Colors.transparent,
-            child: new Stack(
-              children: [
-                createMenuTitle(menuController),
-                createMenuItems(menuController),
-                shouldRenderSelector
+        ),
+        child: new Material(
+          color: Colors.transparent,
+          child: new Stack(
+            children: [
+              createMenuTitle(menuController),
+              createMenuItems(menuController),
+              shouldRenderSelector
                   ? new ItemSelector(
                       topY: actualSelectorYTop,
                       bottomY: actualSelectorYBottom,
                       opacity: selectorOpacity,
                     )
                   : new Container(),
-              ],
-            ),
+            ],
           ),
-        );
-      }
-    );
+        ),
+      );
+    });
   }
 }
 
 class ItemSelector extends ImplicitlyAnimatedWidget {
-
   final double topY;
   final double bottomY;
   final double opacity;
@@ -210,7 +203,6 @@ class ItemSelector extends ImplicitlyAnimatedWidget {
 }
 
 class _ItemSelectorState extends AnimatedWidgetBaseState<ItemSelector> {
-
   Tween<double> _topY;
   Tween<double> _bottomY;
   Tween<double> _opacity;
@@ -250,9 +242,7 @@ class _ItemSelectorState extends AnimatedWidgetBaseState<ItemSelector> {
   }
 }
 
-
 class AnimatedMenuListItem extends ImplicitlyAnimatedWidget {
-
   final _MenuListItem menuListItem;
   final MenuState menuState;
   final bool isSelected;
@@ -270,8 +260,8 @@ class AnimatedMenuListItem extends ImplicitlyAnimatedWidget {
   _AnimatedMenuListItemState createState() => new _AnimatedMenuListItemState();
 }
 
-class _AnimatedMenuListItemState extends AnimatedWidgetBaseState<AnimatedMenuListItem> {
-
+class _AnimatedMenuListItemState
+    extends AnimatedWidgetBaseState<AnimatedMenuListItem> {
   final double closedSlidePosition = 200.0;
   final double openSlidePosition = 0.0;
 
@@ -281,7 +271,8 @@ class _AnimatedMenuListItemState extends AnimatedWidgetBaseState<AnimatedMenuLis
   updateSelectedRenderBox() {
     final renderBox = context.findRenderObject() as RenderBox;
     if (renderBox != null && widget.isSelected) {
-      (menuScreenKey.currentState as _MenuScreenState).setSelectedRenderBox(renderBox);
+      (menuScreenKey.currentState as _MenuScreenState)
+          .setSelectedRenderBox(renderBox);
     }
   }
 
@@ -333,9 +324,7 @@ class _AnimatedMenuListItemState extends AnimatedWidgetBaseState<AnimatedMenuLis
   }
 }
 
-
 class _MenuListItem extends StatelessWidget {
-
   final String title;
   final bool isSelected;
   final Function() onTap;
@@ -350,10 +339,8 @@ class _MenuListItem extends StatelessWidget {
   Widget build(BuildContext context) {
     return new InkWell(
       splashColor: const Color(0x44000000),
-      onTap: isSelected
-          ? null
-          : onTap,
-      child: Container(
+      onTap: isSelected ? null : onTap,
+      child: new Container(
         width: double.infinity,
         child: new Padding(
           padding: const EdgeInsets.only(left: 50.0, top: 15.0, bottom: 15.0),
@@ -381,11 +368,18 @@ class Menu {
 }
 
 class MenuItem {
-  final String id;
+  final MenuItemId id;
   final String title;
 
   MenuItem({
     this.id,
     this.title,
   });
+}
+
+enum MenuItemId {
+  restaurant,
+  other1,
+  other2,
+  other3,
 }

--- a/lib/other_screen.dart
+++ b/lib/other_screen.dart
@@ -1,33 +1,38 @@
 import 'package:flutter/material.dart';
 import 'package:zoom_menu/zoom_scaffold.dart';
 
-final otherScreen = new Screen(
-  title: 'OTHER SCREEN',
-  background: new DecorationImage(
-    image: new AssetImage('assets/other_screen_bk.jpg'),
-    fit: BoxFit.cover,
-    colorFilter: new ColorFilter.mode(const Color(0xCC000000), BlendMode.multiply),
-  ),
-  contentBuilder: (BuildContext context) {
-    return new Center(
-      child: new Container(
-        height: 300.0,
-        child: new Padding(
-          padding: const EdgeInsets.all(25.0),
-          child: new Card(
-            child: new Column(
-              children: [
-                new Image.asset('assets/other_screen_card_photo.jpg'),
-                new Expanded(
-                  child: new Center(
-                    child: new Text('This is another screen!')
+Screen buildOtherScreen(String title) {
+  return new Screen(
+    title: title,
+    background: new DecorationImage(
+      image: new AssetImage('assets/other_screen_bk.jpg'),
+      fit: BoxFit.cover,
+      colorFilter: new ColorFilter.mode(
+        const Color(0xCC000000),
+        BlendMode.multiply,
+      ),
+    ),
+    contentBuilder: (BuildContext context) {
+      return new Center(
+        child: new Container(
+          height: 300.0,
+          child: new Padding(
+            padding: const EdgeInsets.all(25.0),
+            child: new Card(
+              child: new Column(
+                children: [
+                  new Image.asset('assets/other_screen_card_photo.jpg'),
+                  new Expanded(
+                    child: new Center(
+                      child: new Text('This is another screen!'),
+                    ),
                   )
-                )
-              ],
+                ],
+              ),
             ),
           ),
         ),
-      ),
-    );
-  }
-);
+      );
+    },
+  );
+}

--- a/lib/zoom_scaffold.dart
+++ b/lib/zoom_scaffold.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:zoom_menu/menu_screen.dart';
 
 class ZoomScaffold extends StatefulWidget {
-
   final Widget menuScreen;
   final Screen contentScreen;
 
@@ -15,8 +13,8 @@ class ZoomScaffold extends StatefulWidget {
   _ZoomScaffoldState createState() => new _ZoomScaffoldState();
 }
 
-class _ZoomScaffoldState extends State<ZoomScaffold> with TickerProviderStateMixin {
-
+class _ZoomScaffoldState extends State<ZoomScaffold>
+    with TickerProviderStateMixin {
   MenuController menuController;
   Curve scaleDownCurve = new Interval(0.0, 0.3, curve: Curves.easeOut);
   Curve scaleUpCurve = new Interval(0.0, 1.0, curve: Curves.easeOut);
@@ -29,8 +27,7 @@ class _ZoomScaffoldState extends State<ZoomScaffold> with TickerProviderStateMix
 
     menuController = new MenuController(
       vsync: this,
-    )
-    ..addListener(() => setState(() {}));
+    )..addListener(() => setState(() {}));
   }
 
   @override
@@ -40,34 +37,31 @@ class _ZoomScaffoldState extends State<ZoomScaffold> with TickerProviderStateMix
   }
 
   createContentDisplay() {
-    return zoomAndSlideContent(
-      new Container(
-        decoration: new BoxDecoration(
-          image: widget.contentScreen.background,
-        ),
-        child: new Scaffold(
+    return zoomAndSlideContent(new Container(
+      decoration: new BoxDecoration(
+        image: widget.contentScreen.background,
+      ),
+      child: new Scaffold(
+        backgroundColor: Colors.transparent,
+        appBar: new AppBar(
           backgroundColor: Colors.transparent,
-          appBar: new AppBar(
-            backgroundColor: Colors.transparent,
-            elevation: 0.0,
-            leading: new IconButton(
-                icon: new Icon(Icons.menu),
-                onPressed: () {
-                  menuController.toggle();
-                }
-            ),
-            title: new Text(
-              widget.contentScreen.title,
-              style: new TextStyle(
-                fontFamily: 'bebas-neue',
-                fontSize: 25.0,
-              ),
+          elevation: 0.0,
+          leading: new IconButton(
+              icon: new Icon(Icons.menu),
+              onPressed: () {
+                menuController.toggle(context);
+              }),
+          title: new Text(
+            widget.contentScreen.title,
+            style: new TextStyle(
+              fontFamily: 'bebas-neue',
+              fontSize: 25.0,
             ),
           ),
-          body: widget.contentScreen.contentBuilder(context),
         ),
-      )
-    );
+        body: widget.contentScreen.contentBuilder(context),
+      ),
+    ));
   }
 
   zoomAndSlideContent(Widget content) {
@@ -96,8 +90,7 @@ class _ZoomScaffoldState extends State<ZoomScaffold> with TickerProviderStateMix
     final cornerRadius = 10.0 * menuController.percentOpen;
 
     return new Transform(
-      transform: new Matrix4
-        .translationValues(slideAmount, 0.0, 0.0)
+      transform: new Matrix4.translationValues(slideAmount, 0.0, 0.0)
         ..scale(contentScale, contentScale),
       alignment: Alignment.centerLeft,
       child: new Container(
@@ -112,26 +105,21 @@ class _ZoomScaffoldState extends State<ZoomScaffold> with TickerProviderStateMix
           ],
         ),
         child: new ClipRRect(
-          borderRadius: new BorderRadius.circular(cornerRadius),
-          child: content
-        ),
+            borderRadius: new BorderRadius.circular(cornerRadius),
+            child: content),
       ),
     );
   }
 
   @override
   Widget build(BuildContext context) {
-    return Stack(
-      children: [
-        widget.menuScreen,
-        createContentDisplay()
-      ],
+    return new Stack(
+      children: [widget.menuScreen, createContentDisplay()],
     );
   }
 }
 
 class ZoomScaffoldMenuController extends StatefulWidget {
-
   final ZoomScaffoldBuilder builder;
 
   ZoomScaffoldMenuController({
@@ -144,8 +132,8 @@ class ZoomScaffoldMenuController extends StatefulWidget {
   }
 }
 
-class ZoomScaffoldMenuControllerState extends State<ZoomScaffoldMenuController> {
-
+class ZoomScaffoldMenuControllerState
+    extends State<ZoomScaffoldMenuController> {
   MenuController menuController;
 
   @override
@@ -163,9 +151,9 @@ class ZoomScaffoldMenuControllerState extends State<ZoomScaffoldMenuController> 
   }
 
   getMenuController(BuildContext context) {
-    final scaffoldState = context.ancestorStateOfType(
-        new TypeMatcher<_ZoomScaffoldState>()
-    ) as _ZoomScaffoldState;
+    final scaffoldState =
+        context.ancestorStateOfType(new TypeMatcher<_ZoomScaffoldState>())
+            as _ZoomScaffoldState;
     return scaffoldState.menuController;
   }
 
@@ -177,13 +165,10 @@ class ZoomScaffoldMenuControllerState extends State<ZoomScaffoldMenuController> 
   Widget build(BuildContext context) {
     return widget.builder(context, getMenuController(context));
   }
-
 }
 
 typedef Widget ZoomScaffoldBuilder(
-  BuildContext context,
-  MenuController menuController
-);
+    BuildContext context, MenuController menuController);
 
 class Screen {
   final String title;
@@ -201,6 +186,7 @@ class MenuController extends ChangeNotifier {
   final TickerProvider vsync;
   final AnimationController _animationController;
   MenuState state = MenuState.closed;
+  LocalHistoryEntry _historyEntry;
 
   MenuController({
     this.vsync,
@@ -239,19 +225,28 @@ class MenuController extends ChangeNotifier {
     return _animationController.value;
   }
 
-  open() {
+  _open(BuildContext context) {
+    if (_historyEntry == null) {
+      final ModalRoute<dynamic> route = ModalRoute.of(context);
+      if (route != null) {
+        _historyEntry = new LocalHistoryEntry(onRemove: _close);
+        route.addLocalHistoryEntry(_historyEntry);
+      }
+    }
+
     _animationController.forward();
   }
 
-  close() {
+  _close() {
+    _historyEntry = null;
     _animationController.reverse();
   }
 
-  toggle() {
+  toggle(BuildContext context) {
     if (state == MenuState.open) {
-      close();
+      Navigator.pop(context);
     } else if (state == MenuState.closed) {
-      open();
+      _open(context);
     }
   }
 }


### PR DESCRIPTION
Hey hey :)

Thanks so much for the amazing Videos + Resources to help us learn more about animations! I was playing with the code and noticed that the Back Button didn't work on Android. For my own learning, I've been meaning to play with the `LocalHistoryEntry` mechanisms that Flutter provides, and I thought this would be a good opportunity to give it a whirl :)

No pressure to merge or anything, just wanted to share what I'd done and see if ya found it interesting and if helped others at all!

Changes:

  * When the Drawer Opens, add a `LocalHistoryEntry` to the current `ModalRoute`. This will also add a callback to `_close` the drawer (reverse the animation) when someone uses `Navigator.pop` 
  * Make `close` private. To close the drawer, use `Navigator.pop(context)`.
  * When we switch Screens, add a `LocalHistoryEntry` to the Navigator and add a `MenuScreenHistoryEntry` to the `_history` list. The `_history` list is now the Source of truth for what screen is active. When someone pressed the back button, it will pop the last item off the List and rebuild.
  * Turn `otherScreen` into a function that accepts a title. This was easier for visual testing to make sure I'd gotten everything right.
  * Use enum instead of String for `itemId` (not a biggie at all, I just like the IDE warnings ya get if you don't implement every case in a switch statement using an enum)